### PR TITLE
(feature): log panel fuzzy search

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/bubbles v0.16.1
 	github.com/charmbracelet/bubbletea v0.24.2
 	github.com/charmbracelet/lipgloss v0.7.1
+	github.com/sahilm/fuzzy v0.1.0
 	github.com/spf13/cobra v1.7.0
 	github.com/tidwall/gjson v1.17.0
 	k8s.io/api v0.28.1
@@ -17,6 +18,7 @@ require (
 )
 
 require (
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/dlclark/regexp2 v1.4.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/alecthomas/chroma v0.10.0 h1:7XDcGkCQopCNKjZHfYrNLraA+M7e0fMiJ/Mfikbfjek=
 github.com/alecthomas/chroma v0.10.0/go.mod h1:jtJATyUxlIORhUOFNA9NZDWGAQ8wpxQQqNSB4rjA/1s=
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/calyptia/go-bubble-table v0.2.1 h1:NWcVRyGCLuP7QIA29uUFSY+IjmWcmUWHjy5J/CPb0Rk=
@@ -73,6 +75,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/lunixbochs/vtclean v1.0.0 h1:xu2sLAri4lGiovBDQKxl5mrXyESr3gUr5m5SM5+LVb8=
@@ -118,6 +122,8 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sahilm/fuzzy v0.1.0 h1:FzWGaw2Opqyu+794ZQ9SYifWv2EIXpwP4q8dY1kDAwI=
+github.com/sahilm/fuzzy v0.1.0/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/pkg/charm/models/dashboard.go
+++ b/pkg/charm/models/dashboard.go
@@ -32,8 +32,8 @@ func (k DashboardKeyMap) FullHelp() [][]key.Binding {
 
 var DefaultDashboardKeys = DashboardKeyMap{
 	Help: key.NewBinding(
-		key.WithKeys("?"),
-		key.WithHelp("?", "toggle help"),
+		key.WithKeys("ctrl+h"),
+		key.WithHelp("ctrl+h", "toggle help"),
 	),
 	Quit: key.NewBinding(
 		key.WithKeys("q", "ctrl+c"),

--- a/pkg/charm/models/dashboard.go
+++ b/pkg/charm/models/dashboard.go
@@ -36,8 +36,8 @@ var DefaultDashboardKeys = DashboardKeyMap{
 		key.WithHelp("?", "toggle help"),
 	),
 	Quit: key.NewBinding(
-		key.WithKeys("q", "esc", "ctrl+c"),
-		key.WithHelp("q, esc, ctrl+c", "quit"),
+		key.WithKeys("q", "ctrl+c"),
+		key.WithHelp("q, ctrl+c", "quit"),
 	),
 }
 

--- a/pkg/charm/models/panels/logs.go
+++ b/pkg/charm/models/panels/logs.go
@@ -4,42 +4,136 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/sahilm/fuzzy"
 )
+
+type LogsKeyMap struct {
+	Search       key.Binding
+	SubmitSearch key.Binding
+	QuitSearch   key.Binding
+}
+
+// ShortHelp returns keybindings to be shown in the mini help view. It's part
+// of the key.Map interface.
+func (k LogsKeyMap) ShortHelp() []key.Binding {
+	return []key.Binding{}
+}
+
+// FullHelp returns keybindings for the expanded help view. It's part of the
+// key.Map interface.
+func (k LogsKeyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{
+		{k.Search},
+	}
+}
+
+var DefaultLogsKeys = LogsKeyMap{
+	Search: key.NewBinding(
+		key.WithKeys("/"),
+		key.WithHelp("/", "open a prompt to enter a term to fuzzy search logs"),
+	),
+	SubmitSearch: key.NewBinding(
+		key.WithKeys("enter"),
+		key.WithHelp("enter", "submit search prompt"),
+	),
+	QuitSearch: key.NewBinding(
+		key.WithKeys("esc"),
+		key.WithHelp("esc", "exit search mode"),
+	),
+}
+
+const modeLogs = "logs"
+const modeSearching = "searching"
+const modeSearched = "searched"
 
 // Logs is a tea.Model implementation
 // that represents an item panel
 type Logs struct {
-	viewport viewport.Model
-	name     string
-	mutex    *sync.Mutex
-	content  string
+	viewport       viewport.Model
+	searchbar      textinput.Model
+	name           string
+	mutex          *sync.Mutex
+	content        string
+	contentUpdated bool
+	mode           string
 }
 
 func NewLogs(name string, viewport viewport.Model) *Logs {
+	searchbar := textinput.New()
+	searchbar.Prompt = "> "
+	searchbar.Placeholder = "search term"
 	return &Logs{
-		viewport: viewport,
-		name:     name,
-		mutex:    &sync.Mutex{},
-		content:  "",
+		viewport:  viewport,
+		searchbar: searchbar,
+		name:      name,
+		mutex:     &sync.Mutex{},
+		content:   "",
+		mode:      modeLogs,
 	}
 }
 
 func (m *Logs) Init() tea.Cmd { return nil }
 
 func (m *Logs) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
 	var cmd tea.Cmd
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.viewport.Width = msg.Width
 		m.viewport.Height = msg.Height / 2
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, DefaultLogsKeys.Search):
+			m.mode = modeSearching
+			if !m.searchbar.Focused() {
+				m.searchbar.Focus()
+			}
+			m.searchbar.SetValue("")
+			return m, nil
+		case key.Matches(msg, DefaultLogsKeys.QuitSearch):
+			m.mode = modeLogs
+			if m.searchbar.Focused() {
+				m.searchbar.Blur()
+			}
+			m.viewport.SetContent(wrapLogs(m.content, m.viewport.Width))
+			m.contentUpdated = false
+		case key.Matches(msg, DefaultLogsKeys.SubmitSearch):
+			if m.mode == modeSearching {
+				m.mode = modeSearched
+				if m.searchbar.Focused() {
+					m.searchbar.Blur()
+				}
+			}
+		}
 	}
+
+	if m.contentUpdated && m.mode == modeLogs {
+		m.viewport.SetContent(wrapLogs(m.content, m.viewport.Width))
+		m.contentUpdated = false
+	}
+
+	if m.mode == modeSearching {
+		m.searchbar, cmd = m.searchbar.Update(msg)
+		return m, cmd
+	}
+
+	if m.mode == modeSearched {
+		m.viewport.SetContent(m.searchLogs())
+	}
+
 	m.viewport, cmd = m.viewport.Update(msg)
 	return m, cmd
 }
 
 func (m *Logs) View() string {
+	if m.mode == modeSearching {
+		return m.searchbar.View()
+	}
 	return m.viewport.View()
 }
 
@@ -47,11 +141,24 @@ func (m *Logs) AddContent(content string) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	m.content = strings.Join([]string{m.content, content}, "\n")
-	m.viewport.SetContent(wrapLogs(m.content, m.viewport.Width))
+	m.contentUpdated = true
 }
 
 func (m *Logs) Name() string {
 	return m.name
+}
+
+func (m *Logs) searchLogs() string {
+	searchTerm := m.searchbar.Value()
+	splitLogs := strings.Split(m.content, "\n")
+	matches := fuzzy.Find(searchTerm, splitLogs)
+	matchedLogs := []string{}
+	for _, match := range matches {
+		matchedLog := splitLogs[match.Index]
+		// TODO: highlight matched term
+		matchedLogs = append(matchedLogs, matchedLog)
+	}
+	return wrapLogs(strings.Join(matchedLogs, "\n"), m.viewport.Width)
 }
 
 func wrapLogs(logs string, maxWidth int) string {

--- a/pkg/charm/styles/styles.go
+++ b/pkg/charm/styles/styles.go
@@ -31,3 +31,11 @@ func ContentStyle() lipgloss.Style {
 func TableSelectedRowStyle() lipgloss.Style {
 	return lipgloss.NewStyle().Foreground(adaptColor)
 }
+
+func LogSearchHighlightStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(adaptColor)
+}
+
+func LogSearchModeStyle() lipgloss.Style {
+	return lipgloss.NewStyle().Italic(true).Faint(true)
+}


### PR DESCRIPTION
**Description**
- Adds strict/fuzzy search to the logs panel
- Some light refactoring of log paneler logic
- Updates the `Log` panel model to implement the `Helper` interface and show detailed help information for the log panel when full help output is toggled on
- Changes the help toggle key from `?` to `ctrl+h`
- Removed the `esc` key from the global quit key list in favor of making it a local "quit without doing X" key for the panel views

**Motivation**
- resolves #32 